### PR TITLE
NameError with Ruby 1.9.2

### DIFF
--- a/lib/configatron.rb
+++ b/lib/configatron.rb
@@ -1,8 +1,4 @@
 base = File.join(File.dirname(__FILE__), 'configatron')
-if RUBY_VERSION.match(/^1\.9\.2/)
-  require 'syck'
-  ::YAML::ENGINE.yamler = 'syck'
-end
 require 'yamler'
 require 'fileutils'
 require File.join(base, 'configatron')

--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -1,5 +1,10 @@
 class Configatron
   class Store
+    if RUBY_VERSION.match(/^1\.9\.2/)
+      require 'syck'
+      ::YAML::ENGINE.yamler = 'syck'
+    end
+
     alias_method :send!, :send
     
     # Takes an optional Hash of parameters


### PR DESCRIPTION
There was a NameError when using configatron in Ruby 1.9.2:

```
$ /home/webtest/.rvm/rubies/ruby-1.9.2-p180/bin/ruby -S bundle exec rspec     "spec/configatron/rails_spec.rb" "spec/configatron/proc_spec.rb" "spec/lib/class_spec.rb" "spec/lib/configatron_spec.rb"
/home/webtest/git/configatron/lib/configatron/store.rb:312:in `<class:Store>': uninitialized constant Syck::MergeKey (NameError)
```

Ruby 1.9.2 doesn't use Syck for YAML by default, but Psych. That has a compatibility layer, but Syck::MergeKey isn't defined. I'm setting ::YAML::Engine.yamler to 'syck' as well as there was a failure when running the specs otherwise:
    configatron configure_from_yaml should handle merged keys
        Failure/Error: configatron.food.list.should == [:apple, :banana, :tomato, :brocolli, :spinach]
        expected: [:apple, :banana, :tomato, :brocolli, :spinach],
        got: configatron.food.list.<< = [[:apple, :banana, :tomato], [:brocolli, :spinach], ""](using ==)
        Diff:
        @@ -1,2 +1,2 @@
        -[:apple, :banana, :tomato, :brocolli, :spinach]
        +configatron.food.list.<< = [[:apple, :banana, :tomato], [:brocolli, :spinach], ""]
        # ./spec/lib/configatron_spec.rb:309:in `block (3 levels) in <top (required)>'

I'm no expert in this, better solutions are very welcome.
