### PR TITLE
Configuration with blocks

### DIFF
--- a/lib/configatron/configatron.rb
+++ b/lib/configatron/configatron.rb
@@ -11,8 +11,8 @@ class Configatron
   end
   
   # Forwards the method call onto the 'namespaced' Configatron::Store
-  def method_missing(sym, *args)
-    @_store[@_namespace.last].send(sym, *args)
+  def method_missing(sym, *args, &block)
+    @_store[@_namespace.last].send(sym, *args, &block)
   end
   
   # Removes ALL configuration parameters
@@ -27,7 +27,7 @@ class Configatron
   def temp(options = nil)
     begin
       temp_start(options)
-      yield
+      yield @_store[@_namespace.last]
     rescue Exception => e
       raise e
     ensure

--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -141,6 +141,10 @@ class Configatron
         raise Configatron::ProtectedParameter.new(name) if @_protected.include?(name) || methods_include?(name)
         raise Configatron::LockedNamespace.new(@_name) if @_locked && !@_store.has_key?(name)
         @_store[name] = parse_options(*args)
+      elsif sym.to_s.match(/(.+)\?/)
+        return !@_store[$1.to_sym].blank?
+      elsif block_given?
+        yield self.send(sym)
       elsif @_store.has_key?(sym)
         val = @_store[sym]
         if val.is_a?(Configatron::Proc)
@@ -151,8 +155,6 @@ class Configatron
           return res
         end
         return val
-      elsif sym.to_s.match(/(.+)\?/)
-        return !@_store[$1.to_sym].blank?
       else
         store = Configatron::Store.new({}, sym, self)
         @_store[sym] = store

--- a/spec/lib/configatron_spec.rb
+++ b/spec/lib/configatron_spec.rb
@@ -15,6 +15,30 @@ describe "configatron" do
     configatron.foo.test.should == 'hi!'
   end
   
+  describe 'block assignment' do
+    it 'should pass the store to the block' do
+      configatron.test do |c|
+        c.should === configatron.test
+      end
+    end
+
+    it 'should persist changes outside of the block' do
+      configatron.test.one = 1
+      configatron.test.two = 2
+      configatron.test do |c|
+        c.two = 'two'
+      end
+      configatron.test.one.should === 1
+      configatron.test.two.should === 'two'
+    end
+
+    it 'should pass the default store to a temp block' do
+      configatron.temp do |c|
+        c.class.should == Configatron::Store
+      end
+    end
+  end
+
   describe 'exists?' do
     
     it 'should return true or false depending on whether or the setting exists' do


### PR DESCRIPTION
Configuration of deep namespaces can be really verbose.  I've added support for blocks to minimize repetition.

For example:

``` ruby
configatron.letters.a = 'A'
configatron.letters.b = 'B'
configatron.letters.c = 'C'
```

can now be written as:

``` ruby
configatron.letters do |c|
  c.a = 'A'
  c.b = 'B'
  c.c = 'C'
end
```

For consistency #temp, which already accepts a block, now yields the temporary Store.
