### PR TITLE
quick fix for configatron

### DIFF
--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -320,8 +320,12 @@ class Configatron
       undef :test # :nodoc:
     rescue Exception => e
     end
-
-    SYCK_CONSTANT = (RUBY_VERSION.match(/^1\.9/) ? Syck::MergeKey : YAML::Syck::MergeKey)
+   
+    if RUBY_PLATFORM == 'java'
+      SYCK_CONSTANT = YAML::Yecht::MergeKey
+    else
+      SYCK_CONSTANT = (RUBY_VERSION.match(/^1\.9/) ? Syck::MergeKey : YAML::Syck::MergeKey) 
+    end
 
   end # Store
 end # Configatron


### PR DESCRIPTION
When using configatron under jruby, I was getting this error:

```
NameError: uninitialized constant YAML::Syck
    const_missing at org/jruby/RubyModule.java:2528
    (class Store) at /usr/local/rvm/gems/jruby-1.6.0/gems/configatron-2.8.0/lib/configatron/store.rb:324
```

The quick (dirty?) fix was to use YAML::Yecht::MergeKey when jruby is detected instead of YAML::Syck::MergeKey (since syck is not available in jruby, but yecht is supposed to be syck-compatible.)
