### PR TITLE
configatron broken on jruby in 1.9 mode

### DIFF
--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -1,8 +1,8 @@
 class Configatron
   class Store
-    if RUBY_VERSION.match(/^1\.9\.[^1]/) && RUBY_PLATFORM != 'java'
+    if RUBY_VERSION.match(/^1\.9\.[^1]/)
       require 'syck'
-      ::YAML::ENGINE.yamler = 'syck'
+      ::YAML::ENGINE.yamler = 'syck' unless RUBY_PLATFORM == 'java'
     end
 
     alias_method :send!, :send


### PR DESCRIPTION
Hi

I've found that due to some incompatibilities with YAML, configatron doesn't work on jruby with --1.9 flag. This patch fixes it.
