### PR TITLE
Add hash-style getter and setter methods

### DIFF
--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -17,6 +17,14 @@ class Configatron
       @_locked = false
     end
 
+    def [](key)
+      method_missing(key.to_sym)
+    end
+
+    def []=(key, value)
+      method_missing(:"#{key}=", value)
+    end
+
     # Returns a Hash representing the configurations
     def to_hash
       h = Hash.new


### PR DESCRIPTION
This is mostly useful for people doing dynamic configuration lookups,
so you can do configatron[key] rather than configatron.send(key).
