### PR TITLE
Make monkey-patching of the language optional

### DIFF
--- a/lib/configatron.rb
+++ b/lib/configatron.rb
@@ -1,12 +1,17 @@
+# You can require 'configure/core' directly to avoid loading
+# configatron's monkey patches (and you can then set
+# `Configatron.disable_monkey_patchs = true` to enforce this). If you
+# do so, no `configatron` top-level method will be defined for
+# you. You can access the configatron object by Configatron.instance.
+
 base = File.join(File.dirname(__FILE__), 'configatron')
-require 'yamler'
-require 'fileutils'
-require File.join(base, 'configatron')
-require File.join(base, 'store')
-require File.join(base, 'errors')
+require File.join(base, 'core')
+
+if Configatron.disable_monkey_patching
+  raise "Cannot require 'configatron' directly, since monkey patching has been disabled. Run `Configatron.disable_monkey_patching = false` to re-enable it, or always require 'configatron/core' to load Configatron."
+end
+
 require File.join(base, 'core_ext', 'kernel')
 require File.join(base, 'core_ext', 'object')
 require File.join(base, 'core_ext', 'string')
 require File.join(base, 'core_ext', 'class')
-require File.join(base, 'rails')
-require File.join(base, 'proc')

--- a/lib/configatron/core.rb
+++ b/lib/configatron/core.rb
@@ -1,5 +1,14 @@
+require 'fileutils'
 require 'singleton'
 require 'logger'
+require 'yamler'
+
+base = File.dirname(__FILE__)
+
+require File.join(base, 'store')
+require File.join(base, 'errors')
+require File.join(base, 'rails')
+require File.join(base, 'proc')
 
 class Configatron
   include Singleton
@@ -7,7 +16,9 @@ class Configatron
   alias_method :send!, :send
   
   class << self
-    
+
+    attr_accessor :disable_monkey_patching
+
     def log
       unless @logger
         if defined?(::Rails)

--- a/lib/configatron/core_ext/object.rb
+++ b/lib/configatron/core_ext/object.rb
@@ -1,13 +1,9 @@
 class Object # :nodoc:
-  
+
   def send_with_chain(methods, *args) # :nodoc:
     obj = self
     [methods].flatten.each {|m| obj = obj.send(m, *args)}
     obj
-  end
-
-  def blank? # ported ActiveSupport method
-    respond_to?(:empty?) ? empty? : !self
   end
 
 end

--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -148,7 +148,8 @@ class Configatron
         raise Configatron::LockedNamespace.new(@_name) if @_locked && !@_store.has_key?(name)
         @_store[name] = parse_options(*args)
       elsif sym.to_s.match(/(.+)\?/)
-        return !@_store[$1.to_sym].blank?
+        object = @_store[$1.to_sym]
+        return !_object_blank?(object)
       elsif block_given?
         yield self.send(sym)
       elsif @_store.has_key?(sym)
@@ -315,6 +316,10 @@ class Configatron
       else
         return options
       end
+    end
+
+    def _object_blank?(object) # ported ActiveSupport method
+      object.respond_to?(:empty?) ? object.empty? : !object
     end
 
     begin

--- a/spec/lib/class_spec.rb
+++ b/spec/lib/class_spec.rb
@@ -22,24 +22,25 @@ module N
 end
 
 describe Class do
-  
-  describe 'to_configatron' do
-    
-    it 'should return a Configatron::Store object based on the name of the class' do
-      Foo.to_configatron.should be_kind_of(Configatron::Store)
-      Foo.to_configatron.bar.should == :bar
-      A::B::C.to_configatron.d.should == 'D'
+
+  if Class.respond_to?(:to_configatron)
+    describe 'to_configatron' do
+
+      it 'should return a Configatron::Store object based on the name of the class' do
+        Foo.to_configatron.should be_kind_of(Configatron::Store)
+        Foo.to_configatron.bar.should == :bar
+        A::B::C.to_configatron.d.should == 'D'
+      end
+
+      it 'should take an array to prepend to the object' do
+        Foo.to_configatron(:cachetastic).bar.should == 'cachetastic-fubar'
+        N::O.to_configatron(:l, 'm').p.should == 'P'
+      end
+
+      it 'should convert a string to a Store object' do
+        'A::B::C'.to_configatron.d.should == configatron.a.b.c.d
+      end
     end
-    
-    it 'should take an array to prepend to the object' do
-      Foo.to_configatron(:cachetastic).bar.should == 'cachetastic-fubar'
-      N::O.to_configatron(:l, 'm').p.should == 'P'
-    end
-    
-    it 'should convert a string to a Store object' do
-      'A::B::C'.to_configatron.d.should == configatron.a.b.c.d
-    end
-    
   end
-  
+
 end

--- a/spec/lib/configatron_spec.rb
+++ b/spec/lib/configatron_spec.rb
@@ -14,9 +14,9 @@ describe "configatron" do
     configatron.foo.test = 'hi!'
     configatron.foo.test.should == 'hi!'
   end
-  
+
   describe "respond_to" do
-    
+
     it 'should respond_to respond_to?' do
       configatron.test.should be_nil
       configatron.test = 'hi!'
@@ -30,11 +30,11 @@ describe "configatron" do
       configatron.foo.respond_to?(:test).should be_true
       configatron.foo.respond_to?(:plop).should be_false
     end
-    
+
   end
-  
+
   describe 'block assignment' do
-    
+
     it 'should pass the store to the block' do
       configatron.test do |c|
         c.should === configatron.test
@@ -163,7 +163,7 @@ describe "configatron" do
   end
 
   describe 'lock' do
-    
+
     before :each do
       configatron.letters.a = 'A'
       configatron.letters.b = 'B'
@@ -196,7 +196,7 @@ describe "configatron" do
     end
 
     describe 'then unlock' do
-      
+
       before :each do
         configatron.unlock(:letters)
       end
@@ -212,9 +212,9 @@ describe "configatron" do
       it 'should raise an ArgumentError if unknown namespace is unlocked' do
         lambda { configatron.unlock(:numbers).should raise_error(ArgumentError) }
       end
-      
+
     end
-    
+
   end
 
   describe 'temp' do
@@ -356,14 +356,14 @@ describe "configatron" do
       configatron.food.should_not be_nil
       configatron.food.list.should == [:apple, :banana, :tomato, :brocolli, :spinach]
     end
-    
+
     it "should handle complex yaml" do
       configatron.complex_development.bucket.should be_nil
       configatron.configure_from_yaml(File.join(File.dirname(__FILE__), 'complex.yml'))
       configatron.complex_development.bucket.should == 'develop'
       configatron.complex_development.access_key_id.should == 'access_key'
     end
-    
+
   end
 
   it 'should return a parameter' do
@@ -548,46 +548,47 @@ configatron.one = 1
 
   end
 
-  describe :blank? do
+  if Object.new.respond_to?(:blank?)
+    describe :blank? do
 
-    context "uninitialized option" do
-      specify { configatron.foo.bar.should be_blank }
-    end
+      context "uninitialized option" do
+        specify { configatron.foo.bar.should be_blank }
+      end
 
-    context "nil option" do
-      before { configatron.foo.bar = nil }
-      specify { configatron.foo.bar.should be_blank }
-    end
+      context "nil option" do
+        before { configatron.foo.bar = nil }
+        specify { configatron.foo.bar.should be_blank }
+      end
 
-    context "false option" do
-      before { configatron.foo.bar = false }
-      specify { configatron.foo.bar.should be_blank }
-    end
+      context "false option" do
+        before { configatron.foo.bar = false }
+        specify { configatron.foo.bar.should be_blank }
+      end
 
-    context "empty string option" do
-      before { configatron.foo.bar = "" }
-      specify { configatron.foo.bar.should be_blank }
-    end
+      context "empty string option" do
+        before { configatron.foo.bar = "" }
+        specify { configatron.foo.bar.should be_blank }
+      end
 
-    context "empty hash option" do
-      before { configatron.foo.bar = {} }
-      specify { configatron.foo.bar.should be_blank }
-    end
+      context "empty hash option" do
+        before { configatron.foo.bar = {} }
+        specify { configatron.foo.bar.should be_blank }
+      end
 
-    context "empty array option" do
-      before { configatron.foo.bar = [] }
-      specify { configatron.foo.bar.should be_blank }
-    end
+      context "empty array option" do
+        before { configatron.foo.bar = [] }
+        specify { configatron.foo.bar.should be_blank }
+      end
 
-    context "defined option" do
-      before { configatron.foo.bar = 'asd' }
-      subject { configatron.foo.bar }
-      it { should_not be_blank }
-      it { should == 'asd' }
+      context "defined option" do
+        before { configatron.foo.bar = 'asd' }
+        subject { configatron.foo.bar }
+        it { should_not be_blank }
+        it { should == 'asd' }
+      end
+
     end
-    
   end
-
 
   describe "boolean test" do
 
@@ -607,5 +608,5 @@ configatron.one = 1
     end
 
   end
-  
+
 end


### PR DESCRIPTION
In my application, we don't allow monkey-patching of the language. We've found that various libraries tend to monkey-patch in incompatible ways, and it's very hard to excise dependence on a particular monkey-patch once it's in the codebase.

I've made monkey-patching opt-in rather than opt-out, but can change that around if necessary.
