### PR TITLE
Adding required parameter bang notation support (will raise Configatron:...

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Notice how our other configuration parameters haven't changed? Cool, eh?
 You can configure configatron from a hash as well (this is really only useful in testing or for data driven configurat, it's not recommended for actual configuration):
 
 ```ruby
-  configatron.configure_from_hash({:email => {:pop => {:address => 'pop.example.com', :port => 110}}, :smtp => {:address => 'smtp.example.com'}})#### 
+  configatron.configure_from_hash({:email => {:pop => {:address => 'pop.example.com', :port => 110}}, :smtp => {:address => 'smtp.example.com'}})####
   configatron.email.pop.address # => 'pop.example.com'
   configatron.email.pop.port # => 110
   # and so on...
@@ -95,7 +95,7 @@ Of course you can update a single parameter n levels deep as well:
 
 ```ruby
   configatron.email.pop.address = "pop2.example.com"
-  
+
   configatron.email.pop.address # => "pop2.example.com"
   configatron.email.smtp.address # => "smtp.example.com"
 ```
@@ -160,11 +160,11 @@ There are times when you want to refer to one configuration setting in another c
   end
 ```
 
-Now, we could've written that slightly differently, but it helps to illustrate the point. With Configatron you can create `Delayed` and `Dynamic` settings. 
+Now, we could've written that slightly differently, but it helps to illustrate the point. With Configatron you can create `Delayed` and `Dynamic` settings.
 
 #### Delayed
 
-With `Delayed` settings execution of the setting doesn't happen until the first time it is executed. 
+With `Delayed` settings execution of the setting doesn't happen until the first time it is executed.
 
 ```ruby
   configatron.memcached.servers = ['127.0.0.1:11211']
@@ -205,6 +205,14 @@ If you want to get back an actual @nil@ then you can use the @retrieve@ method:
   configatron.i.do.exist = [:some, :array]
   configatron.i.dont.retrieve(:exist, nil) # => nil
   configatron.i.do.retrieve(:exist, :foo) # => [:some, :array]
+```
+
+Alternatively, if a configuration parameter is always required you can append a bang to the property name when accessing it and a `Configatron::RequiredParameter` error will be raised if the property is not configured:
+
+```ruby
+  configatron.missing.required.parameter! # => Configatron::RequiredParameter will be raised
+  configatron.required.parameter = 'required'
+  configatron.required.parameter! # => 'required'
 ```
 
 You can set 'default' values for parameters. If there is already a setting, it won't be replaced. This is useful if you've already done your 'configuration' and you call a library, that needs to have parameters set. The library can set its defaults, without worrying that it might have overridden your custom settings.

--- a/lib/configatron/errors.rb
+++ b/lib/configatron/errors.rb
@@ -10,4 +10,10 @@ class Configatron
       super("Cannot add new parameters to locked namespace: #{name.inspect}")
     end
   end
+
+  class RequiredParameter < StandardError
+    def initialize(name)
+      super("Required parameter missing: #{name.inspect}")
+    end
+  end
 end

--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -142,6 +142,8 @@ class Configatron
     end
 
     def method_missing(sym, *args) # :nodoc:
+      raise_error_if_missing = sym[-1] == '!'
+      sym = sym[0...-1].to_sym if raise_error_if_missing
       if sym.to_s.match(/(.+)=$/)
         name = sym.to_s.gsub("=", '').to_sym
         raise Configatron::ProtectedParameter.new(name) if @_protected.include?(name) || methods_include?(name)
@@ -162,6 +164,7 @@ class Configatron
         end
         return val
       else
+        raise Configatron::RequiredParameter.new(sym.to_s) if raise_error_if_missing
         store = Configatron::Store.new({}, sym, self)
         @_store[sym] = store
         return store

--- a/spec/lib/configatron_spec.rb
+++ b/spec/lib/configatron_spec.rb
@@ -14,9 +14,23 @@ describe "configatron" do
     configatron.foo.test = 'hi!'
     configatron.foo.test.should == 'hi!'
   end
-  
+
+  describe 'required parameters' do
+    it 'should blow up if the property does not exist' do
+      expect { configatron.missing.property! }.to raise_error(Configatron::RequiredParameter)
+    end
+
+    it 'should respond with the property if it exists' do
+      configatron.required.property = 'hi!'
+      configatron.required.property!.should == 'hi!'
+
+      configatron.another.required.property = false
+      configatron.another.required.property!.should be_false
+    end
+  end
+
   describe "respond_to" do
-    
+
     it 'should respond_to respond_to?' do
       configatron.test.should be_nil
       configatron.test = 'hi!'
@@ -30,11 +44,11 @@ describe "configatron" do
       configatron.foo.respond_to?(:test).should be_true
       configatron.foo.respond_to?(:plop).should be_false
     end
-    
+
   end
-  
+
   describe 'block assignment' do
-    
+
     it 'should pass the store to the block' do
       configatron.test do |c|
         c.should === configatron.test
@@ -163,7 +177,7 @@ describe "configatron" do
   end
 
   describe 'lock' do
-    
+
     before :each do
       configatron.letters.a = 'A'
       configatron.letters.b = 'B'
@@ -196,7 +210,7 @@ describe "configatron" do
     end
 
     describe 'then unlock' do
-      
+
       before :each do
         configatron.unlock(:letters)
       end
@@ -212,9 +226,9 @@ describe "configatron" do
       it 'should raise an ArgumentError if unknown namespace is unlocked' do
         lambda { configatron.unlock(:numbers).should raise_error(ArgumentError) }
       end
-      
+
     end
-    
+
   end
 
   describe 'temp' do
@@ -358,14 +372,14 @@ describe "configatron" do
         configatron.food.list.should == [:apple, :banana, :tomato, :brocolli, :spinach]
       end
     end
-    
+
     it "should handle complex yaml" do
       configatron.complex_development.bucket.should be_nil
       configatron.configure_from_yaml(File.join(File.dirname(__FILE__), 'complex.yml'))
       configatron.complex_development.bucket.should == 'develop'
       configatron.complex_development.access_key_id.should == 'access_key'
     end
-    
+
   end
 
   it 'should return a parameter' do
@@ -587,7 +601,7 @@ configatron.one = 1
       it { should_not be_blank }
       it { should == 'asd' }
     end
-    
+
   end
 
 
@@ -609,5 +623,5 @@ configatron.one = 1
     end
 
   end
-  
+
 end


### PR DESCRIPTION
We use configatron extensively in our Rails apps and very much like its simplicity and flexibility, but have been bitten on a few occasions by missing/misconfigured mandatory environment configuration parameters (e.g. a URL to access an external service). Rather than failing fast you get more difficult to trace runtime failures when the `Configatron::Store` instance returned is used as a URL. Being environment specific, this is also the kind of thing your tests don't tend to pick up. 

Yes you can manually check if a given parameter is configured at runtime before using it, but this just makes it more convenient by simply appending a bang when the parameter must be there.
