### PR TITLE
Help out succeed Travis timeout errors while bundle install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-install: bundle install
+install: travis_retry bundle install
 script: bundle exec rake


### PR DESCRIPTION
This allows Travis to retry up to 3 times the `bundle install` command and is very useful to avoid Errored builds due to connectivity issues to rubygems. e.g. [timeout example here](https://travis-ci.org/elgalu/dolarblue/jobs/15508293#L64) that worked thanks to [this](https://github.com/elgalu/dolarblue/blob/master/.travis.yml#L10)
