### PR TITLE
The #key? method should be supported

### DIFF
--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -47,7 +47,7 @@ class Configatron
       @attributes.empty?
     end
 
-    def has_key?(key)
+    def key?(key)
       val = self[key.to_sym]
       !val.is_a?(Configatron::Store)
     end
@@ -98,6 +98,7 @@ class Configatron
 
     alias :[]= :store
     alias :blank? :nil?
+    alias :has_key? :key?
 
     def_delegator :@attributes, :values
     def_delegator :@attributes, :keys

--- a/test/configatron/store_test.rb
+++ b/test/configatron/store_test.rb
@@ -77,6 +77,22 @@ describe Configatron::Store do
 
   end
 
+  context "key?" do
+
+    it "returns true if there is a key" do
+      store.key?(:foo).must_equal false
+      store.foo = "bar"
+      store.key?(:foo).must_equal true
+    end
+
+    it "returns false if the key is a Configatron::Store" do
+      store.key?(:foo).must_equal false
+      store.foo = Configatron::Store.new
+      store.key?(:foo).must_equal false
+    end
+
+  end
+
   context "has_key?" do
 
     it "returns true if there is a key" do


### PR DESCRIPTION
In fact, the `Hash#has_key?` has been (informaly) deprecated by `Hash#key?`
cf. http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/43765
so we should have a `Store#key?` method, and an `Store#has_key?` alias.
