### PR TITLE
Add missing forwardable require.

### DIFF
--- a/lib/configatron/root_store.rb
+++ b/lib/configatron/root_store.rb
@@ -1,4 +1,5 @@
 require 'singleton'
+require 'forwardable'
 
 # This is the root configatron object, and contains methods which
 # operate on the entire configatron hierarchy.


### PR DESCRIPTION
A simple file 'test.rb' like this will reveal the bug:

``` ruby
require 'configatron'
```

`ruby -Ilib test.rb`
