### PR TITLE
Fix delayed attributes.

### DIFF
--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -84,15 +84,7 @@ class Configatron
     end
 
     def method_missing(name, *args, &block)
-      # In case of Configatron bugs, prevent method_missing infinite
-      # loops.
-      if @method_missing
-        ::Kernel.raise ::NoMethodError.new("Bug in configatron; ended up in method_missing while running: #{name.inspect}")
-      end
-      @method_missing = true
       do_lookup(name, *args, &block)
-    ensure
-      @method_missing = false
     end
 
     # Needed for deep_clone to actually clone this object

--- a/test/functional/configatron.rb
+++ b/test/functional/configatron.rb
@@ -59,7 +59,7 @@ class Critic::Functional::ConfigatronTest < Critic::Functional::Test
         @kernel.unknown
       end
     end
-    
+
     it 'responds to nil? for backward compatibility' do
       refute_nil @kernel.a
     end

--- a/test/functional/delayed.rb
+++ b/test/functional/delayed.rb
@@ -1,0 +1,18 @@
+require_relative '_lib'
+
+class Critic::Functional::DelayedTest < Critic::Functional::Test
+  before do
+    @kernel = Configatron::RootStore.new
+  end
+
+  describe 'delayed' do
+    before do
+      @kernel.a = Configatron::Delayed.new { @kernel.b }
+      @kernel.b = "expected"
+    end
+
+    it 'works independent of the order' do
+      assert_equal('expected', @kernel.a)
+    end
+  end
+end


### PR DESCRIPTION
I don't know what kinds of bugs you're trying to protect with this @missing_method variable, but it seems to break delayed attributes. There might be a better solution though.
