### PR TITLE
Stop regexing unnecessarily

### DIFF
--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -151,10 +151,10 @@ class Configatron
         yield self[name]
       else
         name = name.to_s
-        if /(.+)=$/.match(name)
-          return store($1, args[0])
-        elsif /(.+)!/.match(name)
-          key = $1
+        if name.end_with?('=')
+          return store(name[0..-2], args[0])
+        elsif name.end_with?('!')
+          key = name[0..-2]
           if self.has_key?(key)
             return self[key]
           else


### PR DESCRIPTION
ruby-prof shows we're spending way too much time in regexing: an `end_with?` is sufficient and faster.

r? @gdb 