### PR TITLE
Fix a few warnings that appear in ruby 2.5

### DIFF
--- a/lib/configatron/integrations/rails.rb
+++ b/lib/configatron/integrations/rails.rb
@@ -42,7 +42,7 @@ module Configatron::Integrations
       config_files.collect! {|config| File.expand_path(config)}.uniq!
 
       config_files.each do |config|
-        if File.exists?(config)
+        if File.exist?(config)
           # puts "Configuration: #{config}"
           require config
         end

--- a/lib/configatron/proc.rb
+++ b/lib/configatron/proc.rb
@@ -11,7 +11,7 @@ class Configatron
     end
 
     def call
-      unless @val
+      unless defined? @val
         val = self.block.call
         self.execution_count += 1
         if finalize?

--- a/test/functional/configatron.rb
+++ b/test/functional/configatron.rb
@@ -159,7 +159,7 @@ class Critic::Functional::ConfigatronTest < Critic::Functional::Test
   describe 'nil value' do
     it 'remembers a nil value' do
       @kernel.a = nil
-      assert_equal(nil, @kernel.a)
+      assert_nil @kernel.a
     end
   end
 end


### PR DESCRIPTION
Fixed a couple of small warnings that appear when running Configatron with ruby 2.5

```
lib/configatron/proc.rb:14: warning: instance variable @val not initialized

DEPRECATED: Use assert_nil if expecting nil from /Users/kreynolds/Projects/configatron/test/functional/configatron.rb:162. This will fail in Minitest 6.
```