### PR TITLE
Add 4.5.1 history

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 4.5.1
+
+* Replace regex with end_with? in lookup
+
 === 4.5.0
 
 * [backwards-incompatible] Switch from DeepClone to copy-on-write for temp. As part of the implementation, *values* are no longer cloned.


### PR DESCRIPTION
Adding history entry so users can understand what is in the 4.5.1 release on rubygems.org.

I don't think I can create a tag in github without ownership, but it would be great to have a tag for 4.5.1 on 791691348152527c0d67423999d28e87fc43ecf3 as well.

Thanks!