### PR TITLE
Configatron::Store#fetch with a falsey default should work as expected

### DIFF
--- a/lib/configatron/store.rb
+++ b/lib/configatron/store.rb
@@ -71,7 +71,7 @@ class Configatron
       else
         if block
           val = block.call
-        elsif default_value
+        else
           val = default_value
         end
         store(key, val)

--- a/test/unit/configatron/store.rb
+++ b/test/unit/configatron/store.rb
@@ -49,6 +49,11 @@ class Critic::Unit::StoreTest < Critic::Unit::Test
       assert_equal("bar!!", @store.bar)
     end
 
+    it "sets and returns default_value if default is falsey" do
+      assert_equal(false, @store.fetch(:bar, false))
+      assert_equal(false, @store.bar)
+    end
+
     it "sets and returns the value of the block if no value is found" do
       @store.fetch(:bar) do
         "bar!"


### PR DESCRIPTION
Configatron::Store#fetch with a falsey default should set and return that default. At the moment it sets and returns nil, for example:
```
configatron.configure_from_hash(test_config: {})
=> {:test_config=>{}}
configatron.test_config.fetch(:enabled, false)
=> nil
```
One would expect the result to be false. This could be a breaking change for someone, in theory.