### PR TITLE
[DO NOT MERGE] ADM-4148 fix syntax issue with ruby 3.2

### DIFF
--- a/lib/configatron/integrations/rails.rb
+++ b/lib/configatron/integrations/rails.rb
@@ -42,7 +42,7 @@ module Configatron::Integrations
       config_files.collect! {|config| File.expand_path(config)}.uniq!
 
       config_files.each do |config|
-        if File.exists?(config)
+        if File.exist?(config)
           # puts "Configuration: #{config}"
           require config
         end

--- a/lib/configatron/root_store.rb
+++ b/lib/configatron/root_store.rb
@@ -1,4 +1,5 @@
 require 'singleton'
+require 'forwardable'
 
 # This is the root configatron object, and contains methods which
 # operate on the entire configatron hierarchy.


### PR DESCRIPTION
Based on configatron 4.1.0 with syntax fix so it works with ruby 3.2. and rails 6.1.7.3