### PR TITLE
Replace deprecated File.exists? (ruby 3.2)

### DIFF
--- a/lib/configatron/integrations/rails.rb
+++ b/lib/configatron/integrations/rails.rb
@@ -42,7 +42,7 @@ module Configatron::Integrations
       config_files.collect! {|config| File.expand_path(config)}.uniq!
 
       config_files.each do |config|
-        if File.exists?(config)
+        if File.exist?(config)
           # puts "Configuration: #{config}"
           require config
         end


### PR DESCRIPTION
In Ruby 3.2, `File.exists?` is removed. Replace the sole call to this method with `File.exist?`, which is available as far back as Ruby 1.8